### PR TITLE
Use UTF-8 as charset in ThymeleafViewResolver

### DIFF
--- a/docs/tutorials/Thymeleaf-Spring3.md
+++ b/docs/tutorials/Thymeleaf-Spring3.md
@@ -379,6 +379,7 @@ Resolver instances.
    
   <bean class="org.thymeleaf.spring3.view.ThymeleafViewResolver">
     <property name="templateEngine" ref="templateEngine" />
+    <property name="characterEncoding" value="UTF-8" />
   </bean>    
 
     


### PR DESCRIPTION
Since UTF-8 is standard in modern programming world, it's a shame that non-English users of Thymeleaf, which follow this tutorial, have to spend 15 minutes googling to make templates work in their native language.
