### PR TITLE
The last use of .build() to render the uri...

### DIFF
--- a/docs/tutorials/2.1/thymeleafspring.md
+++ b/docs/tutorials/2.1/thymeleafspring.md
@@ -1536,13 +1536,17 @@ For example, for:
 public class ExampleController {
 
     @RequestMapping("/data")
-    public HttpEntity getData(@RequestParam String type) { ... }
+    public String getData(Model model) { ... return "template" }
+
+    @RequestMapping("/data")
+    public String getDataParam(@RequestParam String type) { ... return "template" }
 
 }
 ```
 The following code will create a link to it:
 ```html
-<a th:href="${#mvc.url('EC#getData').arg(0,'internal')}">Get Data</a>
+<a th:href="${(#mvc.url('EC#getData')).build()}">Get Data Param</a>
+<a th:href="${(#mvc.url('EC#getDataParam').arg(0,'internal')).build()}">Get Data Param</a>
 ``` 
 
 You can read more about this mechanism at http://docs.spring.io/spring-framework/docs/4.1.2.RELEASE/spring-framework-reference/html/mvc.html#mvc-links-to-controllers-from-views


### PR DESCRIPTION
Hi,

when i follow the docs (12.1 Building URIs to controllers) to build uri... instead of url, show a class name... it takes me one our to realize that (following docs http://docs.spring.io/spring-framework/docs/4.1.2.RELEASE/spring-framework-reference/html/mvc.html#mvc-links-to-controllers-from-views) that may .build() was missing.

I modify the docs to show this... and change method controller to return "String" because its thymeleaf+spring, and thinks its more clear.

And put an example without params (may you can delete this).

The important ;) the missing .build() ¿i'm wrong?

Thanks.