### PR TITLE
fix API mistake in _The Model Factory_ section

### DIFF
--- a/docs/tutorials/3.0/extendingthymeleaf.md
+++ b/docs/tutorials/3.0/extendingthymeleaf.md
@@ -1318,7 +1318,7 @@ of events by *parsing* it:
 ```java
 final IModel model = 
         modelFactory.parse(
-                context.getTemplateData().getTemplate(), 
+                context.getTemplateData(), 
                 "<div class='headlines'>Some headlines</div>");
 ```
 


### PR DESCRIPTION
In _The Model Factory_ section, modelFactory.parse expects `TemplateData` instead of `String` as the first parameter.

`context.getTemplateData().getTemplate()` => `context.getTemplateData()`