### PR TITLE
Do not pass --smart to pandoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -145,7 +145,6 @@ task generateDocsHTML(
 				"--toc-depth=4",
 				"--section-divs",
 				"--no-highlight",
-				"--smart",
 				"--output=" + outputFile,
 				"${srcDir.path}/${docName}.md"
 			])
@@ -187,7 +186,6 @@ task generateDocsEbook(
 				"--toc",
 				"--toc-depth=4",
 				"--section-divs",
-				"--smart",
 				"--output=" + epubOutputFile,
 				inputFile
 			], file(inputFile.parent))  // We need to set the working dir in order for pandoc to find images


### PR DESCRIPTION
Building with pandoc 2.2.1 results in the following error:
"--smart/-S has been removed.  Use +smart or -smart extension instead.
For example: pandoc -f markdown+smart -t markdown-smart."

See: jgm/pandoc@6f8b967d98ea4270aa2492688fbcdfe8bad150b2

It should be okay to simply not pass --smart to pandoc because the smart
extension is enabled by default for markdown (both input and output):
https://pandoc.org/MANUAL.html#extension-smart