### PR TITLE
Fix API call in the documentation

### DIFF
--- a/docs/tutorials/3.0/usingthymeleaf.md
+++ b/docs/tutorials/3.0/usingthymeleaf.md
@@ -4438,7 +4438,7 @@ of configuration parameters, which include:
  * Encoding to be applied when reading templates:
 
     ```java
-    templateResolver.setEncoding("UTF-8");
+    templateResolver.setCharacterEncoding("UTF-8");
     ```
 
  * Template mode to be used:


### PR DESCRIPTION
The Java call matches now with the API according to https://www.thymeleaf.org/apidocs/thymeleaf/3.0.11.RELEASE/org/thymeleaf/templateresolver/AbstractConfigurableTemplateResolver.html#setCharacterEncoding(java.lang.String)