### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/articles/petclinic.md
+++ b/docs/articles/petclinic.md
@@ -191,7 +191,7 @@ In order to convert this page to Thymeleaf, we will:
 
     <!-- ============================================================================ -->
     <!-- This <head> is only used for static prototyping purposes (natural templates) -->
-    <!-- and is therefore entirely optionl, as this markup fragment will be included  -->
+    <!-- and is therefore entirely optional, as this markup fragment will be included  -->
     <!-- from "fragments.html" at runtime.                                            -->
     <!-- ============================================================================ -->
 
@@ -222,7 +222,7 @@ In order to convert this page to Thymeleaf, we will:
 
         <!-- =========================================================================== -->
         <!-- This div is only used for static prototyping purposes (natural templates)   -->
-        <!-- and is therefore entirely optionl, as this markup fragment will be included -->
+        <!-- and is therefore entirely optional, as this markup fragment will be included -->
         <!-- from "fragments.html" at runtime.                                           -->
         <!-- =========================================================================== -->
 
@@ -272,7 +272,7 @@ In order to convert this page to Thymeleaf, we will:
 
         <!-- =========================================================================== -->
         <!-- This table section is only used for static prototyping purposes (natural    -->
-        <!-- templates) and is therefore entirely optionl, as this markup fragment will  -->
+        <!-- templates) and is therefore entirely optional, as this markup fragment will  -->
         <!-- be included from "fragments.html" at runtime.                               -->
         <!-- =========================================================================== -->
 

--- a/docs/articles/springsecurity.md
+++ b/docs/articles/springsecurity.md
@@ -18,7 +18,7 @@ article will focus on a Spring MVC configuration.
 Prerequisites
 -------------
 
-We asume you are familiar with Thymeleaf and Spring Security, and you
+We assume you are familiar with Thymeleaf and Spring Security, and you
 have a working application using these technologies. If you don't know
 Spring Security, you could be interested on reading the [Spring Security
 Documentation](http://static.springsource.org/spring-security/site/reference.html).

--- a/docs/articles/thvsjsp.md
+++ b/docs/articles/thvsjsp.md
@@ -283,7 +283,7 @@ when we open our browser:
 
 *WHAT? Where's our page gone?* Well, it's still there, but in order to
 make our page work as JSP we had to add lots of JSP tags and features
-that made it work wondefully when executed by our web server... but at
+that made it work wonderfully when executed by our web server... but at
 the same time made it be HTML no more. And therefore made it
 undisplayable for a browser.
 
@@ -305,7 +305,7 @@ For example, there is now an `<input type="email" ...>`, which will make
 our browser check that the text input by users has the shape of an email
 address. And also, there is a new property for all inputs called
 `placeholder` which shows a text in the field that automatically
-dissapears when the input gains focus (usually by the user clicking on
+disappears when the input gains focus (usually by the user clicking on
 it).
 
 Sounds good, doesn't it? Unfortunately not all browsers support this yet

--- a/docs/articles/thymeleaf31whatsnew.md
+++ b/docs/articles/thymeleaf31whatsnew.md
@@ -55,7 +55,7 @@ As an exception to this restriction, some classes in these packages are always _
 
 Some artifacts have been deprecated in Thymeleaf 3.1.
 
-* Deprecated `th:include` in favour of `th:insert`. Note that `th:insert` has sligthly different semantics to `th:include`.
+* Deprecated `th:include` in favour of `th:insert`. Note that `th:insert` has slightly different semantics to `th:include`.
 * Deprecated unwrapped syntax for fragment insertion: now `~{template :: fragment}` should always be used instead of simply `template :: fragment`.
 
 Also, artifacts previously deprecated in 3.0 have been removed:
@@ -103,8 +103,8 @@ Thymeleaf 3.1 introduces three interfaces that abstract the specific details of 
 
   * `org.thymeleaf.web.IWebApplication`: Represents the web application and the attributes associated to it.
   * `org.thymeleaf.web.IWebExchange`: Represents the handling of a web request. Contains the request, the session (if any) and any attributes associated by the application to this specific exchange.
-  * `org.thymeleaf.web.IWebRequest`: Representes a web request: URL path, parameters, headers and cookies.
-  * `org.thymeleaf.web.IWebSession`: Representes a web session if it exists, containing any associated attributes.
+  * `org.thymeleaf.web.IWebRequest`: Represents a web request: URL path, parameters, headers and cookies.
+  * `org.thymeleaf.web.IWebSession`: Represents a web session if it exists, containing any associated attributes.
 
 Even if `IWebApplication` would more or less correspond to the Servlet API's `ServletContext`, there would not be an exact correspondence between the above and other structures in 
 the Servlet API. For instance, part of the data offered by Servlet API's `HttpServletRequest` (like e.g. URL and parameters) would be the contained in an `IWebRequest` object, whereas
@@ -169,7 +169,7 @@ public String contextPath(final HttpServletRequest request) {
 }
 ```
 
-But besides this, as also detailed in the _"What's new"_ section, a hard usage restiction has been established on classes belonging to the JDK and Jakarta EE core
+But besides this, as also detailed in the _"What's new"_ section, a hard usage restriction has been established on classes belonging to the JDK and Jakarta EE core
 classes, with some exceptions. Objects of the forbidden classes will not be usable in variable expressions since Thymeleaf 3.1.
 
 If some of your templates absolutely need to execute expressions on objects of the forbidden classes, you can create a wrapper class (in your own application's package)

--- a/docs/articles/thymeleaf3migration.md
+++ b/docs/articles/thymeleaf3migration.md
@@ -168,7 +168,7 @@ The new textual template modes bring to Thymeleaf the ability to output **CSS**,
 of server-side variables in your CSS and Javascript files, or to generate plain
 text content as, for example, in e-mail composing.
 
-In order to have all Thymeleaf features avaible for the textual modes, a new
+In order to have all Thymeleaf features available for the textual modes, a new
 syntax has been introduced. For example, you can iterate like:
 
 ```text
@@ -433,7 +433,7 @@ Let's highlight a few enhancements of the new Dialect system:
    could, for example, use a pre-processor to serve cached content or a
    post-processor to minimize and compress the output.
  - *Dialect precedence* is a new concept which allows the sorting of processors
-   accross dialects. Processor precedences are now considered relative to
+   across dialects. Processor precedences are now considered relative to
    dialect precedence, so every processor in a specific dialect can be
    configured to be executed before any processors from a different dialect just
    by setting the correct values for this dialect precedence.

--- a/docs/tutorials/3.1/usingthymeleaf.md
+++ b/docs/tutorials/3.1/usingthymeleaf.md
@@ -2218,7 +2218,7 @@ context.setVariable(
      });
 ```
 
-This variable can be used without knowledge of its *lazyness*, in code such as:
+This variable can be used without knowledge of its *laziness*, in code such as:
 
 ```html
 <ul>
@@ -4893,7 +4893,7 @@ like in fragment expressions (`~{...}`).
 
 The impact is extremely small. When a resolved template is marked to use
 decoupled logic and it is not cached, the template logic resource will be
-resolved first, parsed and processed into a secuence of instructions in-memory:
+resolved first, parsed and processed into a sequence of instructions in-memory:
 basically a list of attributes to be injected to each markup selector.
 
 But this is the only *additional step* required because, after this, the real


### PR DESCRIPTION
I found some typos in the following docs and fixed them.

Issue is #89 .

- thymeleaf31whatsnew.md
- usingthymeleaf.md
- springsecurity.md
- petclinic.md
- thvsjsp.md
- thymeleaf3migration.md