### PR TITLE
Spring Security: Use authorities property from authentication instead of principal

### DIFF
--- a/docs/articles/springsecurity.md
+++ b/docs/articles/springsecurity.md
@@ -174,5 +174,5 @@ and roles:
 
 ```html
 Logged user: <span sec:authentication="name">Bob</span>
-Roles: <span sec:authentication="principal.authorities">[ROLE_USER, ROLE_ADMIN]</span>
+Roles: <span sec:authentication="authorities">[ROLE_USER, ROLE_ADMIN]</span>
 ```


### PR DESCRIPTION
The sample to retrieve authorities in Spring Security should be changed to not rely on a specific implementation of principal as principal can be of any type, see https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/Authentication.html#getPrincipal()

A better approach is to get the authorites directly from the authentication object, similar to the username in the line above.

This stack overflow issue shows that users using this snippet are confused:

https://stackoverflow.com/questions/75119716/spring-boot-security-3-thymeleaf-issue-with-secauthentication-principal-auth