### PR TITLE
Fix layout collapses in usingthymeleaf.html on the latest Pandoc

### DIFF
--- a/docs/tutorials/3.0/usingthymeleaf.md
+++ b/docs/tutorials/3.0/usingthymeleaf.md
@@ -1722,6 +1722,7 @@ There are quite a lot of attributes like these, each of them targeting a
 specific HTML5 attribute:
 
 <div class="table-scroller">
+
 ---------------------- ---------------------- ----------------------
 `th:abbr`              `th:accept`            `th:accept-charset`    
 `th:accesskey`         `th:action`            `th:align`             
@@ -1783,6 +1784,7 @@ specific HTML5 attribute:
 `th:vspace`            `th:width`             `th:wrap`              
 `th:xmlbase`           `th:xmllang`           `th:xmlspace`          
 ---------------------- ---------------------- ----------------------
+
 </div>
 
 
@@ -1880,6 +1882,7 @@ set to its fixed value, and if evaluated to false, the attribute will not be set
 The following fixed-value boolean attributes exist in the Standard Dialect:
 
 <div class="table-scroller">
+
 ------------------- ------------------ ------------------
 `th:async`          `th:autofocus`     `th:autoplay`      
 `th:checked`        `th:controls`      `th:declare`       
@@ -1890,6 +1893,7 @@ The following fixed-value boolean attributes exist in the Standard Dialect:
 `th:readonly`       `th:required`      `th:reversed`      
 `th:scoped`         `th:seamless`      `th:selected`      
 ------------------- ------------------ ------------------
+
 </div>
 
 

--- a/docs/tutorials/3.0/usingthymeleaf_ja.md
+++ b/docs/tutorials/3.0/usingthymeleaf_ja.md
@@ -1424,6 +1424,7 @@ Thymeleafもそう思います。なので実際のところ`th:attr`属性が�
 Thymeleafには、このような属性が非常にたくさん用意されていて、それぞれが特定のHTML5属性に対応しています：
 
 <div class="table-scroller">
+
 ---------------------- ---------------------- ----------------------
 `th:abbr`              `th:accept`            `th:accept-charset`
 `th:accesskey`         `th:action`            `th:align`
@@ -1485,6 +1486,7 @@ Thymeleafには、このような属性が非常にたくさん用意されて�
 `th:vspace`            `th:width`             `th:wrap`
 `th:xmlbase`           `th:xmllang`           `th:xmlspace`
 ---------------------- ---------------------- ----------------------
+
 </div>
 
 
@@ -1567,6 +1569,7 @@ HTMLには*真偽値属性*という概念があります。その属性は値�
 スタンダードダイアレクトには次のような固定値真偽値属性があります：
 
 <div class="table-scroller">
+
 ------------------- ------------------ ------------------
 `th:async`          `th:autofocus`     `th:autoplay`
 `th:checked`        `th:controls`      `th:declare`
@@ -1577,6 +1580,7 @@ HTMLには*真偽値属性*という概念があります。その属性は値�
 `th:readonly`       `th:required`      `th:reversed`
 `th:scoped`         `th:seamless`      `th:selected`
 ------------------- ------------------ ------------------
+
 </div>
 
 

--- a/docs/tutorials/3.1/usingthymeleaf.md
+++ b/docs/tutorials/3.1/usingthymeleaf.md
@@ -1729,6 +1729,7 @@ There are quite a lot of attributes like these, each of them targeting a
 specific HTML5 attribute:
 
 <div class="table-scroller">
+
 ---------------------- ---------------------- ----------------------
 `th:abbr`              `th:accept`            `th:accept-charset`    
 `th:accesskey`         `th:action`            `th:align`             
@@ -1790,6 +1791,7 @@ specific HTML5 attribute:
 `th:vspace`            `th:width`             `th:wrap`              
 `th:xmlbase`           `th:xmllang`           `th:xmlspace`          
 ---------------------- ---------------------- ----------------------
+
 </div>
 
 
@@ -1887,6 +1889,7 @@ set to its fixed value, and if evaluated to false, the attribute will not be set
 The following fixed-value boolean attributes exist in the Standard Dialect:
 
 <div class="table-scroller">
+
 ------------------- ------------------ ------------------
 `th:async`          `th:autofocus`     `th:autoplay`      
 `th:checked`        `th:controls`      `th:declare`       
@@ -1897,6 +1900,7 @@ The following fixed-value boolean attributes exist in the Standard Dialect:
 `th:readonly`       `th:required`      `th:reversed`      
 `th:scoped`         `th:seamless`      `th:selected`      
 ------------------- ------------------ ------------------
+
 </div>
 
 


### PR DESCRIPTION
Issue -> https://github.com/thymeleaf/thymeleaf-docs/issues/94

We need a blank line between an HTML tag and Markdown on the latest Pandoc.